### PR TITLE
fix(*): handle moving to the same channel

### DIFF
--- a/src/user.ts
+++ b/src/user.ts
@@ -53,9 +53,13 @@ export class User {
     }
   }
 
-  async moveToChannel(channelId: number): Promise<User> {
+  async moveToChannel(channelId: number): Promise<this> {
     if (!this.client.socket) {
       throw new Error('no socket');
+    }
+
+    if (this.channelId === channelId) {
+      return this;
     }
 
     const channel = this.client.channels.byId(channelId);


### PR DESCRIPTION
If we're trying to move a user to the same channel he's on currently, the mumble server will not respond with any packet, so let's handle it gracefully.