### PR TITLE
fix(*): don't check for permissions before executing commands

### DIFF
--- a/e2e/rejects-creating-channel.e2e-spec.ts
+++ b/e2e/rejects-creating-channel.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { Channel, Client } from '@';
+import { Channel, Client, PermissionDeniedError } from '@';
 import { waitABit } from './utils/wait-a-bit';
 
 describe('Rejects creating channel when there are insufficient permissions (e2e)', () => {
@@ -22,11 +22,15 @@ describe('Rejects creating channel when there are insufficient permissions (e2e)
 
   it('should throw an error when attempting to create a new channel', async () => {
     const channel = client.user?.channel;
-    await expect(channel?.createSubChannel('test')).rejects.toThrow();
+    await expect(channel?.createSubChannel('test')).rejects.toThrow(
+      PermissionDeniedError,
+    );
 
     const one = client.channels.byName('one');
     expect(one).toBeTruthy();
     await client.user?.moveToChannel((one as Channel).id);
-    await expect(channel?.createSubChannel('test')).rejects.toThrow();
+    await expect(channel?.createSubChannel('test')).rejects.toThrow(
+      PermissionDeniedError,
+    );
   });
 });

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -76,11 +76,6 @@ export class Channel {
       throw new Error('no socket');
     }
 
-    const permissions = await this.getPermissions();
-    if (!permissions.canCreateChannel) {
-      throw new InsufficientPermissionsError();
-    }
-
     const newChannelId = await createChannel(this.client.socket, this.id, name);
     return this.client.channels.byId(newChannelId) as Channel;
   }
@@ -88,11 +83,6 @@ export class Channel {
   async remove() {
     if (!this.client.socket) {
       throw new Error('no socket');
-    }
-
-    const permissions = await this.getPermissions();
-    if (!permissions.canRemoveChannel) {
-      throw new InsufficientPermissionsError();
     }
 
     await removeChannel(this.client.socket, this.id);

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -7,7 +7,7 @@ import {
   removeChannel,
   unlinkChannels,
 } from './commands';
-import { InsufficientPermissionsError, NoSuchChannelError } from './errors';
+import { NoSuchChannelError } from './errors';
 import { Permissions } from './permissions';
 import { User } from './user';
 
@@ -108,21 +108,12 @@ export class Channel {
     if (!this.client.socket) {
       throw new Error('no socket');
     }
-
-    if (!(await this.getPermissions()).canLinkChannel) {
-      throw new InsufficientPermissionsError();
-    }
-
     const targetChannel =
       typeof otherChannel === 'number'
         ? this.client.channels.byId(otherChannel)
         : otherChannel;
     if (targetChannel === undefined) {
       throw new NoSuchChannelError(`${otherChannel}`);
-    }
-
-    if (!(await targetChannel.getPermissions()).canLinkChannel) {
-      throw new InsufficientPermissionsError();
     }
 
     await linkChannels(this.client.socket, this.id, targetChannel.id);
@@ -134,20 +125,12 @@ export class Channel {
       throw new Error('no socket');
     }
 
-    if (!(await this.getPermissions()).canLinkChannel) {
-      throw new InsufficientPermissionsError();
-    }
-
     const targetChannel =
       typeof otherChannel === 'number'
         ? this.client.channels.byId(otherChannel)
         : otherChannel;
     if (targetChannel === undefined) {
       throw new NoSuchChannelError(`${otherChannel}`);
-    }
-
-    if (!(await targetChannel.getPermissions()).canLinkChannel) {
-      throw new InsufficientPermissionsError();
     }
 
     await unlinkChannels(this.client.socket, this.id, targetChannel.id);

--- a/src/client.ts
+++ b/src/client.ts
@@ -34,10 +34,12 @@ export class Client extends EventEmitter {
   socket?: MumbleSocket;
   welcomeText?: string;
   readonly options: ClientOptions;
+  readonly providesCertificate;
 
   constructor(options: ClientOptions) {
     super();
     this.options = { ...defaultOptions, ...options };
+    this.providesCertificate = !!options.key && !!options.cert;
   }
 
   async connect(): Promise<this> {

--- a/src/user.ts
+++ b/src/user.ts
@@ -2,7 +2,7 @@ import { filter, takeWhile } from 'rxjs';
 import { UserState } from '@tf2pickup-org/mumble-protocol';
 import { Client } from './client';
 import { Channel } from './channel';
-import { InsufficientPermissionsError, NoSuchChannelError } from './errors';
+import { NoSuchChannelError } from './errors';
 import { filterPacket } from './rxjs-operators/filter-packet';
 import { moveUserToChannel } from './commands';
 
@@ -65,10 +65,6 @@ export class User {
     const channel = this.client.channels.byId(channelId);
     if (!channel) {
       throw new NoSuchChannelError(channelId);
-    }
-
-    if (!(await channel.getPermissions()).canJoinChannel) {
-      throw new InsufficientPermissionsError();
     }
 
     await moveUserToChannel(this.client.socket, this.session, channelId);


### PR DESCRIPTION
I don't know what's going on, but querying Mumble server for permissions apparently sometimes works and sometimes it doesn't. The server just won't respond as it should. So let's just drop checking for permissions and let the user die alone.